### PR TITLE
feat: Dockerize Blueprint Drawer application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# Use an official Node.js runtime as a parent image
+FROM node:18-slim
+
+# Set the working directory in the container
+WORKDIR /usr/src/app
+
+# Copy package.json and package-lock.json (if available)
+COPY package*.json ./
+
+# Install application dependencies
+RUN npm install
+
+# Bundle app source
+COPY . .
+
+# Make port 3000 available to the world outside this container
+EXPOSE 3000
+
+# Define environment variables for Firebase config (placeholders, to be overridden at runtime)
+ENV FIREBASE_CONFIG=""
+ENV APP_ID=""
+ENV PORT=3000
+
+# Run server.js when the container launches
+CMD [ "node", "server.js" ]

--- a/app.html
+++ b/app.html
@@ -117,8 +117,9 @@
         import { getAuth, signInAnonymously, signInWithCustomToken, onAuthStateChanged } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-auth.js";
         import { getFirestore, doc, addDoc, getDoc, collection, getDocs, serverTimestamp, setLogLevel } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
 
-        const firebaseConfig = typeof __firebase_config !== 'undefined' ? JSON.parse(__firebase_config) : null;
-        const appId = typeof __app_id !== 'undefined' ? __app_id : 'default-blueprint-interactive-app';
+        // These will be replaced by a server-side process with actual configuration values.
+        const firebaseConfigString = '__FIREBASE_CONFIG_PLACEHOLDER__';
+        const appId = '__APP_ID_PLACEHOLDER__';
 
         let app, auth, db, userId = null, isAuthReady = false;
 
@@ -175,12 +176,45 @@
         const SELECTION_TOLERANCE = 5; 
         const SELECTION_COLOR = 'rgba(0, 123, 255, 0.7)'; 
 
-        async function initializeFirebase() { 
-            if (!firebaseConfig) {
-                console.error("Firebase config is not available.");
-                showMessage("Error: Firebase configuration missing. App cannot connect to database.", "error");
+        async function initializeFirebase() {
+            let firebaseConfig;
+
+            if (firebaseConfigString === '__FIREBASE_CONFIG_PLACEHOLDER__' || appId === '__APP_ID_PLACEHOLDER__') {
+                console.error("Firebase config placeholders not replaced. Server-side replacement needed.");
+                showMessage("Error: Firebase configuration missing. App requires server-side setup.", "error");
+                // Disable UI elements that depend on Firebase
+                saveBlueprintButton.disabled = true;
+                loadBlueprintButton.disabled = true;
+                refreshBlueprintsButton.disabled = true;
+                undoButton.disabled = true;
+                userIdDisplay.textContent = "Offline Mode";
                 return;
             }
+
+            try {
+                firebaseConfig = JSON.parse(firebaseConfigString);
+            } catch (e) {
+                console.error("Error parsing Firebase config:", e);
+                showMessage("Error: Invalid Firebase configuration format. Check server setup.", "error");
+                saveBlueprintButton.disabled = true;
+                loadBlueprintButton.disabled = true;
+                refreshBlueprintsButton.disabled = true;
+                undoButton.disabled = true;
+                userIdDisplay.textContent = "Offline Mode - Config Error";
+                return;
+            }
+
+            if (!firebaseConfig) { // Handles cases like empty string or null after parsing, though JSON.parse would error on empty string.
+                console.error("Firebase config is null or undefined after parsing.");
+                showMessage("Error: Firebase configuration is invalid or empty. App cannot connect.", "error");
+                saveBlueprintButton.disabled = true;
+                loadBlueprintButton.disabled = true;
+                refreshBlueprintsButton.disabled = true;
+                undoButton.disabled = true;
+                userIdDisplay.textContent = "Offline Mode - Invalid Config";
+                return;
+            }
+
             try {
                 app = initializeApp(firebaseConfig);
                 auth = getAuth(app);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "blueprint-app",
+  "version": "1.0.0",
+  "description": "Blueprint Drawer Interactive Web App",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.17.1"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,52 @@
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.get('/', (req, res) => {
+    const appHtmlPath = path.join(__dirname, 'app.html');
+    fs.readFile(appHtmlPath, 'utf8', (err, htmlContent) => {
+        if (err) {
+            console.error("Error reading app.html:", err);
+            return res.status(500).send("Error loading application HTML.");
+        }
+
+        // Retrieve Firebase config and App ID from environment variables
+        // Default FIREBASE_CONFIG to 'null' (as a string) to ensure valid JSON for client-side parsing
+        const firebaseConf = process.env.FIREBASE_CONFIG || 'null';
+        // Default APP_ID to a specific string if not set
+        const appIdVal = process.env.APP_ID || 'missing-app-id-from-server';
+
+        if (!process.env.FIREBASE_CONFIG) {
+            console.warn("Warning: FIREBASE_CONFIG environment variable is not set. Using 'null' as default.");
+        }
+        if (!process.env.APP_ID) {
+            console.warn("Warning: APP_ID environment variable is not set. Using 'missing-app-id-from-server' as default.");
+        }
+
+        // Replace placeholders
+        let modifiedHtml = htmlContent.replace('__FIREBASE_CONFIG_PLACEHOLDER__', firebaseConf);
+        modifiedHtml = modifiedHtml.replace('__APP_ID_PLACEHOLDER__', appIdVal);
+
+        res.send(modifiedHtml);
+    });
+});
+
+// Serve static assets from the current directory (optional, but useful for CSS/JS if any are separate)
+// For this project, app.html is self-contained with CDN links, but this is good practice.
+// app.use(express.static(__dirname));
+
+app.listen(PORT, () => {
+    console.log(`Server listening on port ${PORT}`);
+    console.log(`Access the app at http://localhost:${PORT}`);
+    if (!process.env.FIREBASE_CONFIG || !process.env.APP_ID) {
+        console.warn("--------------------------------------------------------------------------------------");
+        console.warn("WARNING: FIREBASE_CONFIG or APP_ID environment variables are not set.");
+        console.warn("The application will run in a degraded mode (Firebase will likely show an error client-side).");
+        console.warn("To fully test Firebase integration, set these environment variables before starting the server.");
+        console.warn("Example: FIREBASE_CONFIG='{\"apiKey\": \"...\", ...}' APP_ID='my-app' node server.js");
+        console.warn("--------------------------------------------------------------------------------------");
+    }
+});


### PR DESCRIPTION
This commit introduces Docker support for the Blueprint Drawer Interactive application.

Key changes:
- Modified `app.html` to use placeholders for Firebase configuration (`__FIREBASE_CONFIG_PLACEHOLDER__` and `__APP_ID_PLACEHOLDER__`). The client-side JavaScript now checks for these placeholders and displays an error if they are not replaced, guiding you about missing server-side setup.
- Added `server.js`, a Node.js Express application that serves `app.html`. This server reads `FIREBASE_CONFIG` and `APP_ID` from environment variables and injects them into the HTML content before sending it to the client. It defaults to 'null' for the config and a placeholder for the app ID if the environment variables are not set, allowing the client to handle this gracefully.
- Created `package.json` to manage the `express` dependency for `server.js`.
- Added a `Dockerfile` that packages the Node.js server and the application. It uses a Node.js base image, installs dependencies, and sets up the environment to run the server. Firebase configuration and App ID are expected to be passed as environment variables to the Docker container at runtime.

To run the application using Docker:
1. Build the image: `docker build -t blueprint-app .`
2. Run the container, providing Firebase configuration: ```bash
   docker run -d -p 3000:3000      -e FIREBASE_CONFIG='{"apiKey":"...",...}'      -e APP_ID='your-app-id'      blueprint-app
   ```
Access the application at http://localhost:3000.