### PR TITLE
feat: Dockerize Blueprint Drawer application and add Docker Compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Firebase configuration JSON string.
+# Example: FIREBASE_CONFIG='{"apiKey":"AIzaSyCXXXX","authDomain":"your-project-id.firebaseapp.com","projectId":"your-project-id",...}'
+FIREBASE_CONFIG=""
+
+# Your application ID (used in Firestore paths)
+# Example: APP_ID="my-blueprint-app-v1"
+APP_ID=""
+
+# Port the application server will listen on inside the container (and mapped to host)
+# Default is 3000 if not specified
+PORT=3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: '3.8'
+
+services:
+  blueprint-app:
+    build: . # Specifies to build from the Dockerfile in the current directory
+    image: blueprint-app-image # Optional: names the image if built by compose
+    ports:
+      - "3000:3000" # Maps host port 3000 to container port 3000
+    environment:
+      # FIREBASE_CONFIG: يتم توفيرها عند التشغيل أو من ملف .env
+      # APP_ID: يتم توفيرها عند التشغيل أو من ملف .env
+      # PORT: 3000 # Already set in Dockerfile, but can be overridden here if needed
+      FIREBASE_CONFIG: ${FIREBASE_CONFIG}
+      APP_ID: ${APP_ID}
+      PORT: ${PORT:-3000}
+    # To use an .env file:
+    # Create a file named .env in the same directory as docker-compose.yml
+    # Add your environment variables there, for example:
+    # FIREBASE_CONFIG='{"apiKey":"..."}'
+    # APP_ID='your-app-id'
+    # PORT=3000
+    # Docker Compose will automatically pick up the .env file.
+    # Alternatively, you can specify an env_file:
+    # env_file:
+    #   - ./my-app.env
+    restart: unless-stopped
+
+# Optional: Define a default network if needed for more complex setups
+# networks:
+#   default:
+#     driver: bridge


### PR DESCRIPTION
This commit introduces Docker and Docker Compose support for the Blueprint Drawer Interactive application.

Key changes:
- Modified `app.html` to use placeholders for Firebase configuration (`__FIREBASE_CONFIG_PLACEHOLDER__` and `__APP_ID_PLACEHOLDER__`). The client-side JavaScript now checks for these placeholders and displays an error if they are not replaced, guiding you about missing server-side setup.
- Added `server.js`, a Node.js Express application that serves `app.html`. This server reads `FIREBASE_CONFIG` and `APP_ID` from environment variables and injects them into the HTML content before sending it to the client. It defaults to 'null' for the config and a placeholder for the app ID if the environment variables are not set, allowing the client to handle this gracefully.
- Created `package.json` to manage the `express` dependency for `server.js`.
- Added a `Dockerfile` that packages the Node.js server and the application. It uses a Node.js base image, installs dependencies, and sets up the environment to run the server. Firebase configuration and App ID are expected to be passed as environment variables to the Docker container.
- Added `docker-compose.yml` to simplify building and running the application using Docker Compose. It defines the service, port mappings, and handles environment variables for Firebase configuration (ideally through an `.env` file).
- Added `.env.example` as a template for you to create their `.env` file with the necessary Firebase credentials and application settings.

To run the application using Docker:
1. Build the image: `docker build -t blueprint-app .`
2. Run the container, providing Firebase configuration: ```bash
   docker run -d -p 3000:3000      -e FIREBASE_CONFIG='{"apiKey":"...",...}'      -e APP_ID='your-app-id'      blueprint-app
   ```

To run the application using Docker Compose (recommended):
1. Create an `.env` file from `.env.example` and fill in your Firebase details.
2. Run: `docker-compose up -d`

Access the application at http://localhost:3000 (or the configured port).